### PR TITLE
fix: Do not error if a directive has no options or body

### DIFF
--- a/mdformat_myst/_directives.py
+++ b/mdformat_myst/_directives.py
@@ -100,6 +100,8 @@ def format_directive_content(raw_content: str) -> str:
 
 
 def parse_opts_and_content(raw_content: str) -> tuple[str, str] | None:
+    if not raw_content:
+        return None
     lines = raw_content.splitlines()
     line = lines.pop(0)
     yaml_lines = []

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -394,3 +394,12 @@ letter: a
 ---
 ```
 .
+
+MyST directive, no opts or content
+.
+``` {some-directive} args
+```
+.
+```{some-directive} args
+```
+.


### PR DESCRIPTION
It is allowed to do, for example:

````
```{directive} required argument
```
````