### PR TITLE
FIX: remove cap on `mdit-py-plugins` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = "mdformat,markdown,formatter,gfm"
 requires-python=">=3.7"
 requires=[
     "mdformat >=0.7.0,<0.8.0",
-    "mdit-py-plugins >=0.3.0,<0.4.0",
+    "mdit-py-plugins >=0.3.0",
     "mdformat-tables >=0.4.0",
     "mdformat-frontmatter >=0.3.2",
     "mdformat-footnote >=0.1.1",


### PR DESCRIPTION
Closes: https://github.com/executablebooks/mdformat-myst/issues/27