### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,12 +87,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.8
-    - name: install flit
+    - name: install flit and twine
       run: |
-        pip install flit~=3.0
+        pip install flit~=3.0 twine
     - name: Build and publish
       run: |
-        flit publish
+        flit build
+        twine check --strict dist/*
+        twine upload dist/*
       env:
-        FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
There were two reasons why @KyleKing was [unable to publish on PyPI](https://github.com/executablebooks/mdformat-myst/issues/30#issuecomment-2308411769):
- Flit publish is having issues: https://github.com/pypa/flit/issues/686
- The PyPI token is named PYPI_TOKEN in GitHub settings and PYPI_KEY in tests.yml so they wouldn't match.