### PR TITLE
🚀 RELEASE: v0.2.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,4 +95,4 @@ jobs:
         flit publish
       env:
         FLIT_USERNAME: __token__
-        FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+        FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     - flake8-builtins
     - flake8-comprehensions
 - repo: https://github.com/myint/docformatter
-  rev: v1.7.5
+  rev: eb1df347edd128b30cd3368dddc3aa65edcfac38
   hooks:
   - id: docformatter
 - repo: https://github.com/executablebooks/mdformat

--- a/mdformat_myst/__init__.py
+++ b/mdformat_myst/__init__.py
@@ -1,3 +1,3 @@
 """Mdformat plugin for MyST compatibility."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
Use the configured PyPi Token Secret. There are no actual changes since the v0.2.0 release

Alternative to #32