### PR TITLE
👌 IMPROVE: Support colon fenced directives

### DIFF
--- a/mdformat_myst/plugin.py
+++ b/mdformat_myst/plugin.py
@@ -122,11 +122,12 @@ def container_renderer(
     if children:
         # Look at the tokens forming the first paragraph and see if
         # they form a YAML header. This could be stricter: there
-        # should be exactly three tokens: paragraph start, YAML
+        # should be exactly three tokens: paragraph open, YAML
         # header, paragraph end.
         tokens = children[0].to_tokens()
         if all(
-            not token.content or _YAML_HEADER_PATTERN.fullmatch(token.content)
+            token.type in {'paragraph_open', 'paragraph_close'} or
+                _YAML_HEADER_PATTERN.fullmatch(token.content)
             for token in tokens
         ):
             paragraphs.append('\n'.join(token.content.strip()

--- a/mdformat_myst/plugin.py
+++ b/mdformat_myst/plugin.py
@@ -68,6 +68,7 @@ container_names = [
     "tab-set",
     "table",
     "tip",
+    "todo",
     "topics",
     "warning",
 ]

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -415,7 +415,8 @@ incididunt ut labore et dolore magna aliqua.
 .
 
 :::{admonition} MyST colon fenced directive with simple metadata
-:class: foo :truc: bla
+:class: foo
+:truc: bla
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua.

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -422,6 +422,13 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua.
 :::
 
+::::{admonition} MyST colon fenced directive with nested directive with simple metadata
+:::{image} foo.png
+:class: foo
+:truc: bla
+:::
+::::
+
 % Admonitions with arbitrary yaml metadata are not yet supported.
 % Issue: in a container, the `---` is interpreted as hrule by the parser
 %

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -406,3 +406,86 @@ MyST directive, no opts or content
 ```{some-directive} args
 ```
 .
+
+:::{admonition} MyST colon fenced directive with a title
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+.
+
+:::{admonition} MyST colon fenced directive with simple metadata
+:class: foo :truc: bla
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+% Admonitions with arbitrary yaml metadata are not yet supported.
+% Issue: in a container, the `---` is interpreted as hrule by the parser
+%
+% :::{admonition} MyST colon fenced directive with arbitrary yaml metadata
+% ---
+% foo:
+%   bar: 1
+% ---
+%
+% Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+% incididunt ut labore et dolore magna aliqua.
+% :::
+
+.
+
+% Unknown colon-fenced directives are not yet implemented
+% :::{exercise}
+% This is an unknown admonition.
+% :::
+
+.
+
+::::{admonition} MyST colon fenced directive with two nested admonitions
+:::{admonition}
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+:::{admonition}
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+:::{admonition}
+truc
+:::
+::::
+
+.
+
+::::{hint} A hint with alternating nested tips and texts
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+
+:::{tip}
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+
+:::{tip}
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+:::
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua.
+::::
+
+.
+
+- foo
+  :::{tip} A directive nested in bullet points
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+  incididunt ut labore et dolore magna aliqua.
+  :::


### PR DESCRIPTION
This is a draft of fix for #13. 

I don't really know what I am doing here. So please, anyone familiar with the mdformat / mdit code base improve!  In particular, the list of supported directives is currently hardcoded which is ugly. 
I have first tried to build on top of `mdit_py_plugins.colon_fence` instead of `mdit_py_plugins.container`. This would have avoided to handle metadata manually and removed the need to provide a fixed list of directives; however, the content of the directive is not parsed recursively with `colon_fence`.

Current limitation: yaml metadata delimited by `---` is not supported.
