### PR TITLE
[FIX] Dedent math block if nonzero indent_width found in context

### DIFF
--- a/mdformat_myst/plugin.py
+++ b/mdformat_myst/plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import textwrap
 
 from markdown_it import MarkdownIt
 import mdformat.plugins
@@ -78,11 +79,14 @@ def _math_inline_renderer(node: RenderTreeNode, context: RenderContext) -> str:
 
 
 def _math_block_renderer(node: RenderTreeNode, context: RenderContext) -> str:
+    indent_width = context.env.get("indent_width", 0)
+    if indent_width > 0:
+        return f"$${textwrap.dedent(node.content)}$$"
     return f"$${node.content}$$"
 
 
 def _math_block_label_renderer(node: RenderTreeNode, context: RenderContext) -> str:
-    return f"$${node.content}$$ ({node.info})"
+    return f"{_math_block_renderer(node, context)} ({node.info})"
 
 
 def _math_block_safe_blockquote_renderer(

--- a/tests/data/fixtures.md
+++ b/tests/data/fixtures.md
@@ -260,6 +260,36 @@ $$ (eq1)
 > Some more words
 .
 
+Indented dollarmath block
+.
+1. Indented math block
+
+   $$
+   a=1
+   $$
+.
+1. Indented math block
+
+   $$
+   a=1
+   $$
+.
+
+Indented dollarmath block labeled
+.
+1. Indented labeled math block
+
+   $$
+   a=1
+   $$ (eq1)
+.
+1. Indented labeled math block
+
+   $$
+   a=1
+   $$ (eq1)
+.
+
 Frontmatter
 .
 ---


### PR DESCRIPTION
Fixes #37 

Dedent the contents of the math block if `indent_width` is nonzero in the context. The parent renderer will add back the right amount of indentation.