### PR TITLE
⬆️ UPGRADE: Replace mdformat-tables with mdformat-gfm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,17 +22,17 @@ requires-python=">=3.9"
 requires=[
     "mdformat >=0.7.0",
     "mdit-py-plugins >=0.3.0",
+    "mdformat-tables >=0.4.0; python_version < '3.10'",
     "mdformat-frontmatter >=0.3.2",
     "mdformat-footnote >=0.1.1",
-    "mdformat-gfm >=0.4.0",
+    "mdformat-gfm >=1.0.0; python_version >= '3.10'",
     "ruamel.yaml >=0.16.0",
 ]
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "pytest",
-    "coverage",
-    "pytest-cov",
+    "pytest>=8.0.0",
+    "pytest-cov>=7.0.0",
 ]
 dev = ["pre-commit"]
 


### PR DESCRIPTION
Closes: #43

mdformat-tables was moved to mdformat-gfm. See: https://github.com/hukkin/mdformat-tables/commit/860eaec1ed7220ccd270f9f2f9f10fb17b81274d

Does not yet support mdformat v1 until mdformat-footnote (https://github.com/executablebooks/mdformat-footnote/issues/12) and mdformat-frontmatter (https://github.com/butler54/mdformat-frontmatter/issues/37) are released with updates, which may take some time to resolve

**Update**: mdformat-footnote has been updated and is no longer blocking

